### PR TITLE
Fix URL exception when reading hash part

### DIFF
--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -32,7 +32,7 @@ export function updateQueryParam(
 }
 
 export function getHash(url: string): string {
-  return new URL(url.startsWith("#") ? `${location.host}${url}` : url).hash;
+  return url.slice(Math.max(url.indexOf("#"), 0));
 }
 
 export function updateHash(hash: string, replace = false): void {


### PR DESCRIPTION
Der Teil mit `location.host` wirft eine Exception, weil dies dann keine gültige URL ist (https:// fehlt). Habe das nun umgeschrieben, ohne `URL` Objekt.