### PR TITLE
Do not redirect to home instead of dashboard after login

### DIFF
--- a/src/state/portal-state.ts
+++ b/src/state/portal-state.ts
@@ -143,7 +143,9 @@ export class PortalState extends State {
       this.navigationItemKey =
         url.searchParams.get(NAV_ITEM_QUERY_PARAM) ??
         settings.navigationHome.key;
-      this.appPath = url.hash;
+      if (url.hash && url.hash !== "#" && url.hash !== "#/") {
+        this.appPath = url.hash;
+      }
     });
   }
 


### PR DESCRIPTION
Problem:
- Portal in frischem Tab öffnen (ohne Hash URL)
- Nach dem Login wird zurück auf `#/` (Home mit Links der Module) statt auf `#/dashboard` (Startseite des Portals) redirected

Sollte mit diesem Change gefixt sein.