### PR TITLE
Fix Kursausschreibung hash routing #558

### DIFF
--- a/public/scripts/iframe.js
+++ b/public/scripts/iframe.js
@@ -35,6 +35,7 @@ if (typeof locale === "string") {
 
 ///// Notify portal on state (URL) changes /////
 
+// Post pushState calls to parent window
 const pushState = history.pushState;
 history.pushState = (...args) => {
   pushState.call(history, ...args);
@@ -44,6 +45,7 @@ history.pushState = (...args) => {
   );
 };
 
+// Post replaceState calls to parent window
 const replaceState = history.replaceState;
 history.replaceState = (...args) => {
   replaceState.call(history, ...args);
@@ -52,3 +54,11 @@ history.replaceState = (...args) => {
     parent.window.origin
   );
 };
+
+// Post hashchange events to parent window
+window.addEventListener("hashchange", (event) => {
+  parent.window.postMessage(
+    { type: "bkdAppHashChange", url: event.newURL },
+    parent.window.origin
+  );
+});

--- a/src/components/Portal.ts
+++ b/src/components/Portal.ts
@@ -136,6 +136,11 @@ export class Portal extends LitElement {
         updateHash(getHash(url), true);
         break;
       }
+      case "bkdAppHashChange": {
+        const { url } = data;
+        updateHash(getHash(url));
+        break;
+      }
     }
   };
 

--- a/src/state/portal-state.ts
+++ b/src/state/portal-state.ts
@@ -205,8 +205,8 @@ export class PortalState extends State {
         // Consume `initialAppPath`
         this.appPath = this.initialAppPath;
 
-        // Make sure we are still on on the same app path, if it has
-        // been changed from loading the dashboard
+        // Make sure we are still on the same app path, if it has been
+        // changed from loading the dashboard
         const url = new URL(document.location.href);
         url.hash = this.appPath;
         history.replaceState({}, "", url);


### PR DESCRIPTION
Die Kursausschreibung App updated die URL wahrscheinlich über `window.location.hash = "bla";`, deshalb habe ich implementiert, dass auch `hashchange` Events vom iframe nach draussen propagiert werden.