### PR TITLE
Handle case insensitive urls for noteneingabe #571

### DIFF
--- a/public/apps/Noteneingabe/appConfig.js
+++ b/public/apps/Noteneingabe/appConfig.js
@@ -8,7 +8,7 @@
         // API base URL without trailing slash
         apiUrl: window.parent.eventoPortal.settings.apiServer,
         // base Url of the web application without trailing slash (also the redirect url for public clients)
-        webBaseUrl:  '../',
+        webBaseUrl:  '.',
         // url to a page that handles login without trailing slash. Provide a value here, if you are not using
         // CLX.Evento OAuth Server for Authentication, but a login form on your website
         loginUrl: '../Evt_Pages/Login.aspx',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,15 +8,20 @@ import { defineConfig } from "vite";
 const EventoEmberAppsCasePlugin = {
   name: "evento-ember-apps-case",
   configureServer(server) {
-    server.middlewares.use("/apps/EmberApps", (req, res, next) => {
-      req.url = req.url
-        .replace("components", "Components")
-        .replace("controllers", "Controllers")
-        .replace("templates", "Templates")
-        .replace("views", "Views")
-        .replace("//JSModules", "");
-      next();
-    });
+    server.middlewares
+      .use("/apps/EmberApps", (req, res, next) => {
+        req.url = req.url
+          .replace("components", "Components")
+          .replace("controllers", "Controllers")
+          .replace("templates", "Templates")
+          .replace("views", "Views")
+          .replace("//JSModules", "");
+        next();
+      })
+      .use("/apps/Noteneingabe", (req, res, next) => {
+        req.url = req.url.replace("components", "Components");
+        next();
+      });
   },
 };
 


### PR DESCRIPTION
Ich habe eine weitere Rule für die Noteneingabe-App in der Middleware-Konfig von vite erfasst.

Desweiteren musste ich bei der Config der App selbst die `webBaseUrl` anpassen, ansonsten wurde der `CSS`-Ordner eine Ebene zu weit oben gesucht.