### PR TITLE
Do not add tolerance to calculated height to prevent resize loop #579

### DIFF
--- a/public/scripts/iframe.js
+++ b/public/scripts/iframe.js
@@ -90,7 +90,7 @@ function postAppResize(height) {
   parent.window.postMessage(
     {
       type: "bkdAppResize",
-      height: Math.max(maxBottom, viewportHeight) + tolerance,
+      height: Math.max(maxBottom + tolerance, viewportHeight),
     },
     window.parent.origin
   );


### PR DESCRIPTION
Siehe auch https://github.com/bkd-mba-fbi/webapp-schulverwaltung/issues/579

Wenn die Toleranz zur berechneten maximalen Height hinzugefügt wird, führt dies zu einem Resize-Endlos-Loop in Chrome-basierten Browsern.

Die Toleranz ist grundsätzlich nötig, damit bei Dropdowns (z.B. unter "Absenzen bearbeiten") kein zweiter Scrollbalken innerhalb des Iframes angezeigt wird.