### PR TITLE
add * to case sensitive match

### DIFF
--- a/build/evento.conf
+++ b/build/evento.conf
@@ -9,8 +9,8 @@ server {
     index  index.html index.htm;
 
     location / {
-        location ~* ^/apps/emberapps/ {
-            # case sensitive match for path /apps/EmberApps
+        location ~* ^/apps/emberapps/* {
+            # case sensitive match for path /apps/EmberApps/
         }
     }
 


### PR DESCRIPTION
Hallo Sandro

Ich vermute, dass wohl der "*" gefehlt hat. War mir nicht sicher, ob es denn wirklich braucht. Das Problem könnte aber auch woanders liegen. Müsste es am besten lokal kurz testen.

Gruss