### PR TITLE
Fix login instance preset by using auth endpoint getter #118

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -43,7 +43,9 @@ export function createOAuthClient(): OAuth2Client {
     server: envSettings.oAuthServer,
     clientId: envSettings.oAuthClientId,
     tokenEndpoint: `${envSettings.oAuthPrefix}/Authorization/Token`,
-    authorizationEndpoint: getAuthorizationEndpoint(),
+    get authorizationEndpoint() {
+      return getAuthorizationEndpoint();
+    },
     fetch: (...args) => fetch(...args), // Fix for https://github.com/badgateway/oauth2-client/issues/105
   });
 }


### PR DESCRIPTION
#118

Das Problem war, dass wir die Login-URL (Setting auf dem Auth-Client) initial, statisch gesetzt hatten, dies zu einem Zeitpunkt wo die `bkdInstance` im localStorage beim ersten Zurückkommen vom OAuth Provider noch nicht gesetzt war. Deshalb war beim Logout nachdem das allererste Mal eingeloggt wurde, die Instance nicht in der Login-URL enthalten. Falls man jedoch reloaded hatte und der Auth-Client neu erstellt wurde, war die Login-URL mit Instance korrekt konfiguriert und der Logout funktionierte wie gewünscht.

Es ist offenbar nicht möglich dieses Setting auf dem Auth-Client zu updaten (nur Getter vorhanden), aber zum Glück wird es stets vom Settings Objekt gelesen, so dass wir es in einen Getter umwandeln können. So wird dann die URL zum Zeitpunkt wo sie benötigt wird neu ermittelt, mit dem jeweilig korrekten `bkdInstance` Wert aus dem localStorage.