### PR TITLE
Active token for new scope after redirect to home #106

### DIFF
--- a/src/components/Content.ts
+++ b/src/components/Content.ts
@@ -6,6 +6,8 @@ import { keyed } from "lit/directives/keyed.js";
 import { localized } from "@lit/localize";
 import { theme } from "../utils/theme";
 import { when } from "lit/directives/when.js";
+import { getCurrentAccessToken } from "../utils/storage";
+import { tokenMatchesScope } from "../utils/token";
 
 @customElement("bkd-content")
 @localized()
@@ -93,7 +95,15 @@ export class Content extends LitElement {
   }
 
   render() {
-    // The keyed directive ensures that the entire iframe and any associated scripts are removed when the application changes.
+    if (!tokenMatchesScope(getCurrentAccessToken(), portalState.app.scope)) {
+      // Token scope does not match current app, wait for correct
+      // token to be activated in <Portal> component to avoid requests
+      // resulting in 403 due to unsufficient rights.
+      return html`<main></main>`;
+    }
+
+    // The keyed directive ensures that the entire iframe and any
+    // associated scripts are removed when the application changes.
     return html`
       <main>
         ${when(

--- a/src/state/portal-state.ts
+++ b/src/state/portal-state.ts
@@ -64,7 +64,7 @@ export class PortalState extends State {
   actualAppPath: string | null = null;
 
   private setInitialized: () => void = () => undefined;
-  private initialized = new Promise(
+  initialized = new Promise(
     (resolve) => (this.setInitialized = () => resolve(null)),
   );
 

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -84,6 +84,17 @@ export function isTokenHalfExpired(
   return expirationTime <= now + validFor / 2;
 }
 
+/**
+ * Returns whether the given token matches the given scope.
+ */
+export function tokenMatchesScope(
+  token: string | null,
+  scope: string,
+): boolean {
+  const tokenScope = token && getTokenPayload(token).scope;
+  return tokenScope === scope;
+}
+
 function parseTokenPayload(token: string): RawTokenPayload {
   const base64Url = token.split(".")[1];
   const base64 = base64Url.replace("-", "+").replace("_", "/");


### PR DESCRIPTION
See #106