### PR TITLE
Kursausschreibung scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@ Download the [latest build](https://bkd-mba-fbi.github.io/evento-portal/evento-p
 - [Browser Support](./doc/browser-support.md)
 - [Architecture](./doc/architecture.md)
 - [Authentication via OAuth 2.0](./doc/auth.md)
+- [App Integration with iframe](./doc/app-integration.md)
 - [Branching, Releasing & Deployment](./doc/releasing.md)

--- a/doc/app-integration.md
+++ b/doc/app-integration.md
@@ -1,0 +1,49 @@
+[back](../README.md)
+
+# App Integration with iframe
+
+The integration of the various _apps_ (i.e. micro frontends) is achieved with an `<iframe>` to ensure a separation of the runtime environments, a proper cleanup when switching _apps_ and no memory leaks. However, this method comes with some trade-offs & issues.
+
+The [public/scripts/iframe.js](../public/scripts/iframe.js) script solves most of these issues and has to be included in an _app_'s `index.html`. It sets up communication between portal & iframe and initializes workarounds.
+
+## URL Synchronization
+
+_Apps_ can use client-side hash-routing, that means using the [hash part](https://developer.mozilla.org/en-US/docs/Web/API/URL/hash) of the URL to store application state. The _Evento Portal_ ensures, that the hash part is mapped from the `<iframe>`'s URL to the URL in the browser's location bar and vice versa. This synchronization is achieved as follows:
+
+- `iframe.js`: Wraps the history API in the iframe to post messages about state changes to the _Evento Portal_:
+  - `history.pushState` in iframe → `bkdAppPushState` message in portal
+  - `history.replaceState` in iframe → `bkdAppReplaceState` message in portal
+  - `hashchange` event in iframe → `bkdAppHashChange` message in portal
+- `<bkd-portal>` component: Registers the above message events and updates the portal state & URL. It also registers the `hashchange` event to propagate changes of the browser's URL to the iframe URL.
+
+## iframe Resizing
+
+Since an iframe has a fixed size, its width & height have to be constantly adjusted to the _app_'s document/contents. A special challenge are absolute positioned elements (like dropdowns or overlays) that just overflow if larger than the document and not cause the document to grow.
+
+The resizing of the iframe is implemented as such:
+
+- `iframe.js`: A `ResizeObserver` is used to track changes to the overall height of the _app_'s document. A `bkdAppResize` message is posted if the height changes.
+- `iframe.js`: A `MutationObserver` is used to track the addition or removal of any absolute positioned nodes and to determine the bottom most element with absolute positioning. A `bkdAppResize` message is posted if the height changes.
+- `<bkd-content>` component: Registers the `bkdAppResize` messages and sets the given height on the `<iframe>`.
+
+## Scrolling
+
+Since the iframe is constantly resized, it never has a vertical scrollbar. This is an issue when _apps_ want to scroll programmatically. Thus the `frame.js` scripts monkey-patches the following parts of the browser API to apply the scrolling in the _Evento Portal_ window instead, incorporating the iframe's top offset:
+
+- `window.scrollTo` & `window.scroll`
+- `window.scrollBy`
+- `window.scrollY` & `window.pageYOffset`
+- `Element.prototype.getBoundingClientRect`
+- `Element.prototype.scrollIntoView` (an element is always top aligned, the `alignToTop`, `block` and `inline` options are not supported)
+
+These functions/properties can be used safely by _apps_. What does not work is the `scroll` event.
+
+## Positioning of Elements
+
+Positioning elements relative to the viewport/scroll position – such as modal dialogs – is an issue. The CSS rule `position: fixed` does not work, since the iframe is not a scrolling container (the element will stick to the top of the iframe in this case). _Apps_ have to consider the _Evento Portal_ window's scroll position and the iframe's offset in this case.
+
+Checkout the [BkdModalService](https://github.com/bkd-mba-fbi/webapp-schulverwaltung/blob/main/src/app/shared/services/bkd-modal.service.ts) of the webapp-schulverwaltung as an example.
+
+## Language Attribute
+
+The `iframe.js` script applies the _Evento Portal_'s HTML `lang` attribute to the _app_'s document.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -15,7 +15,7 @@
 
 ## App Integration/Evento Portal API
 
-A static build of the _apps_ is committed to this repository in the [public/apps/](../public/apps/) directory. The _Evento Portal_ loads the _apps_ in an `<iframe>` to ensure a separation of the runtime environment, a proper cleanup when switching _apps_ and no memory leaks. The [public/scripts/iframe.js](../public/scripts/iframe.js) script has to be included in an _app_'s `index.html` to setup communication between portal & iframe.
+A static build of the _apps_ is committed to this repository in the [public/apps/](../public/apps/) directory. The _Evento Portal_ loads the _apps_ in an `<iframe>` to ensure a separation of the runtime environment, a proper cleanup when switching _apps_ and no memory leaks. For more details see [App Integration with iframe](./app-integration.md).
 
 _Apps_ can use client-side hash-routing, that means using the [hash part](https://developer.mozilla.org/en-US/docs/Web/API/URL/hash) of the URL to store application state. The _Evento Portal_ ensures, that the hash part is mapped from the `<iframe>`'s URL to the browser URL and vice versa.
 

--- a/public/apps/Kursausschreibung/settings.js
+++ b/public/apps/Kursausschreibung/settings.js
@@ -196,12 +196,12 @@ window.kursausschreibung.settings = {
     // when a field is optional or not in the form you can set a default value.
 	// it will overwrite null values in the post to the person endpoint (optional)
     "personDefaultValue": {"CountryId": "CH"},
-    
+
     // property by which the event-list should be sorted (optional)
     "sortEventList": "SubscriptionDateTo",
 
     // Header Offset for scrolling
-    "headerOffset": 55,
+    "headerOffset": 0,
 
     //Button "Subscription with login" visibility when url to content with login readable
     "subscriptionWithLoginURL": null,

--- a/public/scripts/iframe.js
+++ b/public/scripts/iframe.js
@@ -109,8 +109,17 @@ function getMaxPositionedBottom() {
   }, 0);
 }
 
-window.onload = () => {
-  resizeObserver.observe(document.documentElement);
+window.addEventListener("load", () => {
+  // For reasons we don't understand, the <body> in the
+  // kursauschreibung app always has full height in Chrome (not in
+  // Firefox), although there is no CSS causing this and the child
+  // element is smaller. As a workaround we observe the child in the
+  // kursausschreibung app. See also
+  // https://github.com/bkd-mba-fbi/evento-portal/issues/117
+  const mainElement = document.getElementById("kursausschreibung-root")
+    ? document.querySelector("body > div")
+    : document.documentElement;
+  resizeObserver.observe(mainElement);
 
   const body = document.querySelector("body");
   if (body) {
@@ -119,7 +128,7 @@ window.onload = () => {
       childList: true,
     });
   }
-};
+});
 
 ///// HTML lang attribute updating /////
 

--- a/public/scripts/iframe.js
+++ b/public/scripts/iframe.js
@@ -116,9 +116,10 @@ window.addEventListener("load", () => {
   // element is smaller. As a workaround we observe the child in the
   // kursausschreibung app. See also
   // https://github.com/bkd-mba-fbi/evento-portal/issues/117
-  const mainElement = document.getElementById("kursausschreibung-root")
-    ? document.querySelector("body > div")
-    : document.documentElement;
+  const mainElement =
+    (document.getElementById("kursausschreibung-root") &&
+      document.querySelector("body > div")) ||
+    document.documentElement;
   resizeObserver.observe(mainElement);
 
   const body = document.querySelector("body");
@@ -167,3 +168,172 @@ window.addEventListener("hashchange", (event) => {
     parent.window.origin,
   );
 });
+
+///// Scrolling /////
+
+// Since the iframe is always resized to contain the full height of
+// its contents (with the observers above), it never has
+// scrollbars. So if the app wants to scroll vertically or read the
+// vertical scroll position, we have to do this in the Evento Portal
+// window, while also considering the iframe's top-offset within the
+// portal. Therefore we monkey-patch the scroll-relevant browser APIs
+// to make the app's scroll logic work.
+
+/**
+ * @type {any}
+ */
+const iFrameScrollTo = window.scrollTo;
+
+/**
+ * Monkey-patch `window.scrollTo` & `window.scroll` to scroll Evento
+ * Portal window instead.
+ *
+ * @param {...*} args
+ * @returns {void}
+ */
+function patchedScrollTo(...args) {
+  if (args.length === 2) {
+    const [x, y] = args;
+
+    // Scroll portal vertically
+    window.parent.scrollTo(0, y + getPortalOffset());
+
+    // Scroll iframe horizontally
+    iFrameScrollTo.call(window, x, 0);
+  } else if (args[0]) {
+    const { top, left, behavior } = args[0];
+    if (top != null) {
+      // Scroll portal vertically
+      window.parent.scrollTo({
+        top: top + getPortalOffset(),
+        behavior,
+      });
+    }
+    if (left != null) {
+      // Scroll iframe horizontally
+      iFrameScrollTo.call(window, { left, behavior });
+    }
+  }
+}
+window.scrollTo = patchedScrollTo;
+window.scroll = patchedScrollTo;
+
+/**
+ * @type {any}
+ */
+const iFrameScrollBy = window.scrollBy;
+
+/**
+ * Monkey-patch `window.scrollBy` to scroll Evento Portal window
+ * instead.
+ *
+ * @param {...*} args
+ * @returns {void}
+ */
+function patchedScrollBy(...args) {
+  if (args.length === 2) {
+    const [x, y] = args;
+
+    // Scroll portal vertically
+    window.parent.scrollBy(0, y);
+
+    // Scroll iframe horizontally
+    iFrameScrollBy.call(window, x, 0);
+  } else if (args[0]) {
+    const { top, left, behavior } = args[0];
+    if (top != null) {
+      // Scroll portal vertically
+      window.parent.scrollBy({ top, behavior });
+    }
+    if (left != null) {
+      // Scroll iframe horizontally
+      iFrameScrollBy.call(window, { left, behavior });
+    }
+  }
+}
+window.scrollBy = patchedScrollBy;
+
+/**
+ * Monkey-patch the `window.scrollY` & `window.pageYOffset`
+ * read-only properties to return the Evento Portal window's scroll
+ * position instead.
+ *
+ * @returns {number}
+ */
+function patchedScrollY() {
+  return Math.max(window.parent.scrollY - getPortalOffset(), 0);
+}
+Object.defineProperty(window, "scrollY", { get: patchedScrollY });
+Object.defineProperty(window, "pageYOffset", { get: patchedScrollY });
+
+const iFrameGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+
+/**
+ * Monkey-patch `Element.prototype.getBoundingClientRect` to
+ * incorporate Evento Portal window scroll position.
+ *
+ * @returns {DOMRect}
+ * @this {Element}
+ */
+function patchedGetBoundingClientRect() {
+  const rect = iFrameGetBoundingClientRect.call(this);
+  const y = rect.y - window.scrollY;
+  return new DOMRect(rect.x, y, rect.width, rect.height);
+}
+Element.prototype.getBoundingClientRect = patchedGetBoundingClientRect;
+
+/**
+ * Monkey-patch `window.scrollIntoView` to scroll Evento Portal window
+ * instead.
+ *
+ * @param {Parameters<typeof Element.prototype.scrollIntoView>[0]} arg
+ * @returns {void}
+ * @this {Element}
+ */
+function patchedScrollIntoView(arg) {
+  let behavior;
+  if (typeof arg === "object") {
+    behavior = arg?.behavior;
+    if (arg?.block) {
+      console.warn(
+        "The block option is not supported by the simulated scrollIntoView of the Evento Portal",
+      );
+    }
+    if (arg?.inline) {
+      console.warn(
+        "The inline option is not supported by the simulated scrollIntoView of the Evento Portal",
+      );
+    }
+  } else if (typeof arg === "boolean") {
+    console.warn(
+      "The alignToTop option is not supported by the simulated scrollIntoView of the Evento Portal",
+    );
+  }
+
+  const { top, bottom } = this.getBoundingClientRect();
+  const viewportTop = window.parent.scrollY;
+  const viewportBottom = viewportTop + window.parent.innerHeight;
+  const offset = getPortalOffset();
+
+  if (top + offset < viewportTop || bottom + offset > viewportBottom) {
+    window.parent.scrollTo({ top: top + offset, behavior });
+  }
+}
+Element.prototype.scrollIntoView = patchedScrollIntoView;
+
+/**
+ * Returns the offset of the iframe to the top of the Evento Portal
+ * document.
+ *
+ * @returns {number}
+ */
+function getPortalOffset() {
+  const parentDocument = window.parent.document;
+  const portalRoot = parentDocument?.querySelector("bkd-portal")?.shadowRoot;
+  const contentRoot = portalRoot?.querySelector("bkd-content")?.shadowRoot;
+  const iframe = contentRoot?.querySelector("iframe");
+  return (
+    (iframe?.getBoundingClientRect()?.top ?? 0) +
+    parentDocument.documentElement.scrollTop
+  );
+}


### PR DESCRIPTION
Siehe #117

- [x] Kursausschreibung: iframe Resizing Problem in Chrome fixen
- [x] Allgemein: `window.scrollTo`/`window.scroll` monkey-patchen und in parent anwenden inkl. iframe-Offset
- [x] Allgemein: `window.scrollBy` monkey-patchen und in parent anwenden
- [x] Allgemein: `window.scrollY` → mit getter monkey-patchen
- [x] Allgemein: `Element.scrollIntoView` monkey-patchen und in parent anwenden inkl. iframe-Offset
- [x] Schulverwaltung: Anpassen des `ScrollPositionService`? → https://github.com/bkd-mba-fbi/webapp-schulverwaltung/pull/652
- [ ] ~~Schulverwaltung: funktioniert ngx-infinite-scroll überhaupt noch oder muss noch der `infiniteScrollContainer` definiert werden? Wie ist es mit dem iframe-Offset?~~ → Auf die Schnelle keine Lösung gefunden, es funktioniert aber mit dem Fallback Button.