### PR TITLE
Fix redirect loop when token is already expired #63

### DIFF
--- a/src/utils/token-renewal.ts
+++ b/src/utils/token-renewal.ts
@@ -82,14 +82,17 @@ function onExpiration(
     clearTimeout(expirationTimers[type]);
   }
 
-  if (token) {
-    expirationTimers[type] = setTimeout(callback, getTokenExpireIn(token));
+  const expireIn = token && getTokenExpireIn(token);
+  // Don't set timer for already expired token since it will be
+  // handled by the auth.ts logic and would cause a redirection loop
+  if (expireIn && expireIn > 0) {
+    expirationTimers[type] = setTimeout(callback, expireIn);
     logLazy(() => {
       const { expirationTime } = token;
       const expirationDate = new Date();
       expirationDate.setTime(expirationTime * 1000);
       return `Scheduled ${type} token expiration timeout in ${Math.floor(
-        getTokenExpireIn(token) / 1000 / 60,
+        expireIn / 1000 / 60,
       )} minutes (at ${expirationDate})`;
     });
   }


### PR DESCRIPTION
Siehe #63

Es gab ein Redirect Loop, wenn das Access Token ablief oder wen. die Seite neu geladen wurde und das Access Token war bereits expired. Mit diesem Change wird nur ein Timer gesetzt, wenn das Token nicht bereits abgeloffen ist – bei Tokens die bereits abgelaufen sind greift die normale Logik in `auth.ts`, wenn man auf die Seite kommt.

Kann getestet werden mit der `browserstack` Client ID mit `npm run start:browserstack` (Access Token ist dort 2 Minuten gültig). Für mehr Transparent in `logging.ts` die Variable `const loggingEnabled = true;` setzen (ist ein Production Build, deshalb wird sonst nicht geloggt).