### PR TITLE
fix scrollbar flickering on iframe resizing overflow hidden

### DIFF
--- a/public/scripts/iframe.js
+++ b/public/scripts/iframe.js
@@ -8,6 +8,11 @@
 ///// iframe resizing /////
 
 /**
+ * Fix scrollbar flickering on iframe resizing. Hidden overflow-y on html element.
+ */
+document.getElementsByTagName("html")[0].style.overflowY = "hidden";
+
+/**
  * An array to track the absolute positioned elements
  *
  * @type {Array<Node>}

--- a/public/scripts/iframe.js
+++ b/public/scripts/iframe.js
@@ -10,7 +10,7 @@
 /**
  * Fix scrollbar flickering on iframe resizing. Hidden overflow-y on html element.
  */
-document.getElementsByTagName("html")[0].style.overflowY = "hidden";
+document.documentElement.style.overflowY = "hidden";
 
 /**
  * An array to track the absolute positioned elements


### PR DESCRIPTION
Im iframe html element wird die y scrollbar auf hidden gestellt, damit gibt es kein flickering mehr beim resizing.