### PR TITLE
Asynchronously refresh tokens #157

### DIFF
--- a/cypress/e2e/auth.cy.ts
+++ b/cypress/e2e/auth.cy.ts
@@ -1,0 +1,410 @@
+import {
+  resetAllTokens,
+  storeAccessToken,
+  storeCurrentAccessToken,
+  storeRefreshToken,
+} from "../../src/utils/storage";
+import { createToken } from "../support/commands";
+
+const SCOPE = "Tutoring";
+const OTHER_SCOPE = "Public";
+
+const TEN_MINUTES = 10 * 60 * 1000;
+const HALF_HOUR = 30 * 60 * 1000;
+const ONE_HOUR = 60 * 60 * 1000;
+
+describe("Authentication", () => {
+  beforeEach(() => {
+    cy.resizeToDesktop();
+    cy.login({
+      locale: "de-CH",
+      roles: ["LessonTeacherRole", "TeacherRole"],
+      permissions: [],
+    });
+
+    // Remove all tokens created by cy.login from storage so the
+    // following tests can setup custom scenarios
+    cy.window().then(() => {
+      resetAllTokens();
+    });
+  });
+
+  describe("token handling on visit", () => {
+    it("renders app if current token has correct scope", () => {
+      const refreshToken = createToken(SCOPE, { locale: "de-CH" });
+      const accessToken = createToken(SCOPE, { locale: "de-CH" });
+      cy.window().then(() => {
+        storeRefreshToken(SCOPE, refreshToken);
+        storeAccessToken(SCOPE, accessToken);
+        storeCurrentAccessToken(accessToken);
+      });
+
+      cy.visitPortal("/index.html");
+      cy.iframeContains("h2", "Stundenplan");
+      expectCurrentToken(accessToken);
+    });
+
+    it("renders app if current token has different scope and cached token for desired scope is available", () => {
+      const refreshToken = createToken(SCOPE, { locale: "de-CH" });
+      const accessToken = createToken(SCOPE, { locale: "de-CH" });
+      const otherRefreshToken = createToken(OTHER_SCOPE, { locale: "de-CH" });
+      const otherAccessToken = createToken(OTHER_SCOPE, { locale: "de-CH" });
+      cy.window().then(() => {
+        storeRefreshToken(SCOPE, refreshToken);
+        storeAccessToken(SCOPE, accessToken);
+
+        storeRefreshToken(OTHER_SCOPE, otherRefreshToken);
+        storeAccessToken(OTHER_SCOPE, otherAccessToken);
+        storeCurrentAccessToken(otherAccessToken);
+      });
+
+      cy.visitPortal("/index.html");
+      cy.iframeContains("h2", "Stundenplan");
+      expectCurrentToken(accessToken);
+    });
+
+    it("renews token if current token has correct scope but is expired", () => {
+      const initialRefreshToken = createToken(SCOPE, { locale: "de-CH" });
+      const initialAccessToken = createToken(SCOPE, {
+        locale: "de-CH",
+        expiration: Math.floor((Date.now() - ONE_HOUR) / 1000),
+      });
+      const renewedRefreshToken = createToken(SCOPE, { locale: "de-CH" });
+      const renewedAccessToken = createToken(SCOPE, { locale: "de-CH" });
+      cy.window().then(() => {
+        storeRefreshToken(SCOPE, initialRefreshToken);
+        storeAccessToken(SCOPE, initialAccessToken);
+        storeCurrentAccessToken(initialAccessToken);
+      });
+
+      interceptTokenRenewal(renewedRefreshToken, renewedAccessToken).as(
+        "tokenRenewal",
+      );
+
+      cy.visitPortal("/index.html");
+      cy.iframeContains("h2", "Stundenplan");
+      cy.wait("@tokenRenewal").its("request").should("exist");
+      expectCurrentToken(renewedAccessToken);
+    });
+
+    it("renews token if current token has different scope and cached token for desired scope is available but expired", () => {
+      const initialRefreshToken = createToken(SCOPE, { locale: "de-CH" });
+      const initialAccessToken = createToken(SCOPE, {
+        locale: "de-CH",
+        expiration: Math.floor((Date.now() - ONE_HOUR) / 1000),
+      });
+      const renewedRefreshToken = createToken(SCOPE, { locale: "de-CH" });
+      const renewedAccessToken = createToken(SCOPE, { locale: "de-CH" });
+      const otherRefreshToken = createToken(OTHER_SCOPE, { locale: "de-CH" });
+      const otherAccessToken = createToken(OTHER_SCOPE, { locale: "de-CH" });
+      cy.window().then(() => {
+        storeRefreshToken(SCOPE, initialRefreshToken);
+        storeAccessToken(SCOPE, initialAccessToken);
+
+        storeRefreshToken(OTHER_SCOPE, otherRefreshToken);
+        storeAccessToken(OTHER_SCOPE, otherAccessToken);
+        storeCurrentAccessToken(otherAccessToken);
+      });
+      interceptTokenRenewal(renewedRefreshToken, renewedAccessToken).as(
+        "tokenRenewal",
+      );
+
+      cy.visitPortal("/index.html");
+      cy.iframeContains("h2", "Stundenplan");
+      cy.wait("@tokenRenewal").its("request").should("exist");
+      expectCurrentToken(renewedAccessToken);
+    });
+
+    it("redirects to login page if current token has different scope but cached token for required scope is unavailable", () => {
+      const otherRefreshToken = createToken(OTHER_SCOPE, { locale: "de-CH" });
+      const otherAccessToken = createToken(OTHER_SCOPE, { locale: "de-CH" });
+      cy.window().then(() => {
+        storeRefreshToken(OTHER_SCOPE, otherRefreshToken);
+        storeAccessToken(OTHER_SCOPE, otherAccessToken);
+        storeCurrentAccessToken(otherAccessToken);
+      });
+
+      expectLoginRedirect(() => {
+        cy.visit("/index.html");
+      });
+    });
+
+    it("redirects to login page if no tokens are available", () => {
+      expectLoginRedirect(() => {
+        cy.visit("/index.html");
+      });
+    });
+
+    it("redirects to login page if refresh token has correct scope but expired", () => {
+      // Hypothetical case where refresh token is already expired
+      // but access token is not, but it makes sure we test the
+      // correct logic
+      const refreshToken = createToken(SCOPE, {
+        locale: "de-CH",
+        expiration: Math.floor((Date.now() - ONE_HOUR) / 1000),
+      });
+      const accessToken = createToken(SCOPE, { locale: "de-CH" });
+      cy.window().then(() => {
+        storeRefreshToken(SCOPE, refreshToken);
+        storeAccessToken(SCOPE, accessToken);
+        storeCurrentAccessToken(accessToken);
+      });
+
+      expectLoginRedirect(() => {
+        cy.visit("/index.html");
+      });
+    });
+
+    it("redirects to login page when token renewal fails", () => {
+      const refreshToken = createToken(SCOPE, { locale: "de-CH" });
+      const accessToken = createToken(SCOPE, {
+        locale: "de-CH",
+        expiration: Math.floor((Date.now() - ONE_HOUR) / 1000),
+      });
+      cy.window().then(() => {
+        storeRefreshToken(SCOPE, refreshToken);
+        storeAccessToken(SCOPE, accessToken);
+        storeCurrentAccessToken(accessToken);
+      });
+      cy.intercept(
+        "https://eventotest.api/OAuth/Authorization/Test/Token",
+        {
+          method: "POST",
+          times: 1,
+        },
+        { statusCode: 401, body: { error: "invalid_grant" } },
+      ).as("tokenRenewal");
+
+      expectLoginRedirect(() => {
+        cy.visit("/index.html");
+      });
+      cy.wait("@tokenRenewal").its("request").should("exist");
+    });
+  });
+
+  describe("token handling on navigation", () => {
+    it("renders app when switching to another module of same app (i.e. same scope)", () => {
+      const refreshToken = createToken(SCOPE, { locale: "de-CH" });
+      const accessToken = createToken(SCOPE, { locale: "de-CH" });
+      cy.window().then(() => {
+        storeRefreshToken(SCOPE, refreshToken);
+        storeAccessToken(SCOPE, accessToken);
+        storeCurrentAccessToken(accessToken);
+      });
+
+      cy.visitPortal("/index.html");
+      cy.iframeContains("h2", "Stundenplan");
+      expectCurrentToken(accessToken);
+
+      // Switch to another module of same app
+      navigate("Unterricht", "Präsenzkontrolle");
+      cy.iframeContains("h1", "Präsenzkontrolle");
+      expectCurrentToken(accessToken);
+    });
+
+    it("renders app when switching to app with different scope and cached token is available", () => {
+      const refreshToken = createToken(SCOPE, { locale: "de-CH" });
+      const accessToken = createToken(SCOPE, { locale: "de-CH" });
+      const otherRefreshToken = createToken(OTHER_SCOPE, { locale: "de-CH" });
+      const otherAccessToken = createToken(OTHER_SCOPE, { locale: "de-CH" });
+      cy.window().then(() => {
+        storeRefreshToken(SCOPE, refreshToken);
+        storeAccessToken(SCOPE, accessToken);
+        storeCurrentAccessToken(accessToken);
+
+        storeRefreshToken(OTHER_SCOPE, otherRefreshToken);
+        storeAccessToken(OTHER_SCOPE, otherAccessToken);
+      });
+
+      cy.visitPortal("/index.html");
+      cy.iframeContains("h2", "Stundenplan");
+      expectCurrentToken(accessToken);
+
+      // Switch to app with other scope
+      navigate("Angebote", "Kurse und Veranstaltungen");
+      cy.iframeContains("Freie Plätze");
+      expectCurrentToken(otherAccessToken);
+    });
+
+    it("redirects to login when switching to app with different scope but cached token is unavailable", () => {
+      const refreshToken = createToken(SCOPE, { locale: "de-CH" });
+      const accessToken = createToken(SCOPE, { locale: "de-CH" });
+      cy.window().then(() => {
+        storeRefreshToken(SCOPE, refreshToken);
+        storeAccessToken(SCOPE, accessToken);
+        storeCurrentAccessToken(accessToken);
+      });
+
+      cy.visitPortal("/index.html");
+      cy.iframeContains("h2", "Stundenplan");
+      expectCurrentToken(accessToken);
+
+      // Switch to app with other scope
+      expectLoginRedirect(() => {
+        navigate("Angebote", "Kurse und Veranstaltungen");
+      });
+    });
+
+    it("renews token when switching to app with different scope and cached token is available but expired", () => {
+      const refreshToken = createToken(SCOPE, { locale: "de-CH" });
+      const accessToken = createToken(SCOPE, { locale: "de-CH" });
+      const otherRefreshToken = createToken(OTHER_SCOPE, { locale: "de-CH" });
+      const otherAccessToken = createToken(OTHER_SCOPE, {
+        locale: "de-CH",
+        expiration: Math.floor((Date.now() - ONE_HOUR) / 1000),
+      });
+      const renewedOtherRefreshToken = createToken(OTHER_SCOPE, {
+        locale: "de-CH",
+      });
+      const renewedOtherAccessToken = createToken(OTHER_SCOPE, {
+        locale: "de-CH",
+      });
+      cy.window().then(() => {
+        storeRefreshToken(SCOPE, refreshToken);
+        storeAccessToken(SCOPE, accessToken);
+        storeCurrentAccessToken(accessToken);
+
+        storeRefreshToken(OTHER_SCOPE, otherRefreshToken);
+        storeAccessToken(OTHER_SCOPE, otherAccessToken);
+      });
+
+      cy.visitPortal("/index.html");
+      cy.iframeContains("h2", "Stundenplan");
+
+      interceptTokenRenewal(
+        renewedOtherRefreshToken,
+        renewedOtherAccessToken,
+      ).as("tokenRenewal");
+
+      // Switch to app with other scope
+      navigate("Angebote", "Kurse und Veranstaltungen");
+      cy.wait("@tokenRenewal").its("request").should("exist");
+      cy.iframeContains("Freie Plätze");
+      expectCurrentToken(renewedOtherAccessToken);
+    });
+  });
+
+  describe("token handling while app is in use", () => {
+    it("renews access token in the background when it expires and redirects to login when refresh token expires", () => {
+      const now = new Date();
+      cy.clock(now);
+
+      // Initial token pair
+      const time1 = now.getTime();
+      const refreshToken1 = createToken(SCOPE, {
+        locale: "de-CH",
+        expiration: Math.floor((time1 + HALF_HOUR) / 1000),
+      });
+      const accessToken1 = createToken(SCOPE, {
+        locale: "de-CH",
+        expiration: Math.floor((time1 + TEN_MINUTES) / 1000),
+      });
+
+      // Renewed token pair with renewed but same expirations
+      const time2 = time1 + TEN_MINUTES;
+      const refreshToken2 = createToken(SCOPE, {
+        locale: "de-CH",
+        expiration: Math.floor((time2 + HALF_HOUR) / 1000),
+      });
+      const accessToken2 = createToken(SCOPE, {
+        locale: "de-CH",
+        expiration: Math.floor((time2 + TEN_MINUTES) / 1000),
+      });
+
+      // Another renewed token pair, this time with a refresh token
+      // that expires first (to test refresh token expiration)
+      const time3 = time2 + TEN_MINUTES;
+      const refreshToken3 = createToken(SCOPE, {
+        locale: "de-CH",
+        expiration: Math.floor((time3 + HALF_HOUR) / 1000),
+      });
+      const accessToken3 = createToken(SCOPE, {
+        locale: "de-CH",
+        expiration: Math.floor((time3 + ONE_HOUR) / 1000),
+      });
+
+      cy.window().then(() => {
+        storeRefreshToken(SCOPE, refreshToken1);
+        storeAccessToken(SCOPE, accessToken1);
+        storeCurrentAccessToken(accessToken1);
+      });
+
+      // We have valid tokens initially
+      cy.visitPortal("/index.html");
+      cy.iframeContains("h2", "Stundenplan");
+      expectCurrentToken(accessToken1);
+
+      // Access token expires after 10 minutes and is renewed
+      interceptTokenRenewal(refreshToken2, accessToken2).as(
+        "firstTokenRenewal",
+      );
+      cy.tick(TEN_MINUTES);
+      cy.wait("@firstTokenRenewal").its("request").should("exist");
+      expectCurrentToken(accessToken2);
+
+      // Access token expires again after 10 minutes and is renewed
+      interceptTokenRenewal(refreshToken3, accessToken3).as(
+        "secondTokenRenewal",
+      );
+      cy.tick(TEN_MINUTES);
+      cy.wait("@secondTokenRenewal").its("request").should("exist");
+
+      // Unfortunately, due to weird behavior in the context of mocked timers
+      // and cross origin tests, the following is not working when executed in
+      // headless mode (the tests will hang and won't terminate). Since it works
+      // in headed mode we skip it for now in headless mode.
+      const headed = Cypress.config("isInteractive");
+      if (headed) {
+        // Refresh token expires, redirects to login
+        expectLoginRedirect(() => {
+          cy.tick(HALF_HOUR);
+        });
+      }
+    });
+  });
+});
+
+function expectCurrentToken(accessToken: string) {
+  cy.get("iframe").should((iframe) => {
+    const storage = iframe[0].contentWindow.localStorage;
+    expect(storage.getItem("CLX.LoginToken")).to.eq(`"${accessToken}"`);
+  });
+}
+
+function expectLoginRedirect(callback: () => void) {
+  cy.intercept(
+    "https://eventotest.api/OAuth/Authorization/Test/Login?*",
+    "<html><body>Login</body></html>",
+  );
+  callback();
+  cy.origin("https://eventotest.api", () => {
+    cy.contains("Login").should("exist");
+  });
+}
+
+function interceptTokenRenewal(refreshToken: string, accessToken: string) {
+  return cy.intercept(
+    "https://eventotest.api/OAuth/Authorization/Test/Token",
+    {
+      method: "POST",
+      times: 1,
+    },
+    {
+      refresh_token: refreshToken,
+      access_token: accessToken,
+      expires_in: 0, // Not relevant/unused
+    },
+  );
+}
+
+function navigate(menuName: string, itemName: string) {
+  cy.contains("a", menuName).as("menuToggle").should("exist").click();
+
+  cy.get("@menuToggle")
+    .next("bkd-nav-group-dropdown")
+    .shadow()
+    .find("ul[role='menu']")
+    .contains("a[role='menuitem']", itemName)
+    .should("exist")
+    .click();
+}

--- a/cypress/e2e/footer.cy.ts
+++ b/cypress/e2e/footer.cy.ts
@@ -9,7 +9,7 @@ describe("Footer", () => {
     });
 
     it("renders the footer with links to contact, legal and imprint pages", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
 
       cy.get("bkd-footer").within(() => {
         cy.get("a").contains("Kontakt");
@@ -19,7 +19,7 @@ describe("Footer", () => {
     });
 
     it("renders the static contact page", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       cy.get("bkd-footer").find("a").contains("Kontakt").click();
 
       cy.get("h1").contains("Kontakt", {});
@@ -28,7 +28,7 @@ describe("Footer", () => {
     });
 
     it("renders the static legal page", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       cy.get("bkd-footer").find("a").contains("Rechtliche Hinweise").click();
 
       cy.get("h1").contains("Rechtliche Hinweise", {});
@@ -37,7 +37,7 @@ describe("Footer", () => {
     });
 
     it("renders the static imprint page", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       cy.get("bkd-footer").find("a").contains("Impressum").click();
 
       cy.get("h1").contains("Impressum", {});
@@ -52,7 +52,7 @@ describe("Footer", () => {
     });
 
     it("renders the footer with links to contact, legal and imprint pages", () => {
-      cy.visit("/index.html?locale=fr-CH");
+      cy.visitPortal("/index.html?locale=fr-CH");
       cy.get("bkd-footer").within(() => {
         cy.get("a").contains("Contact");
         cy.get("a").contains("Mentions légales");
@@ -61,7 +61,7 @@ describe("Footer", () => {
     });
 
     it("renders the static contact page", () => {
-      cy.visit("/index.html?locale=fr-CH");
+      cy.visitPortal("/index.html?locale=fr-CH");
       cy.get("bkd-footer").find("a").contains("Contact").click();
 
       cy.get("h1").contains("Contact", {});
@@ -70,7 +70,7 @@ describe("Footer", () => {
     });
 
     it("renders the static legal page", () => {
-      cy.visit("/index.html?locale=fr-CH");
+      cy.visitPortal("/index.html?locale=fr-CH");
       cy.get("bkd-footer").find("a").contains("Mentions légales").click();
 
       cy.get("h1").contains("Mentions légales", {});
@@ -79,7 +79,7 @@ describe("Footer", () => {
     });
 
     it("renders the static imprint page", () => {
-      cy.visit("/index.html?locale=fr-CH");
+      cy.visitPortal("/index.html?locale=fr-CH");
       cy.get("bkd-footer").find("a").contains("Impressum").click();
 
       cy.get("h1").contains("Impressum", {});

--- a/cypress/e2e/navigationMenu.cy.ts
+++ b/cypress/e2e/navigationMenu.cy.ts
@@ -10,7 +10,7 @@ describe("Navigation Menu", () => {
     describe("desktop", () => {
       beforeEach(() => {
         cy.resizeToDesktop();
-        cy.visit("/index.html");
+        cy.visitPortal("/index.html");
       });
 
       it("renders main navigation", () => {
@@ -69,7 +69,7 @@ describe("Navigation Menu", () => {
     describe("mobile", () => {
       beforeEach(() => {
         cy.resizeToMobile();
-        cy.visit("/index.html");
+        cy.visitPortal("/index.html");
       });
 
       it("open/closes hamburger menu by click on hamburger", () => {
@@ -144,7 +144,7 @@ describe("Navigation Menu", () => {
     beforeEach(() => {
       cy.login({ roles: ["StudentRole"], permissions: [] });
       cy.resizeToMobile();
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
     });
 
     it("only renders allowed groups & items", () => {
@@ -169,7 +169,7 @@ describe("Navigation Menu", () => {
         permissions: [],
       });
       cy.resizeToMobile();
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
     });
 
     it("only renders allowed groups & items", () => {
@@ -206,7 +206,7 @@ describe("Navigation Menu", () => {
     beforeEach(() => {
       cy.login({ roles: ["ClassTeacherRole"], permissions: [] });
       cy.resizeToMobile();
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
     });
 
     it("only renders allowed groups & items", () => {
@@ -237,7 +237,7 @@ describe("Navigation Menu", () => {
     beforeEach(() => {
       cy.login({ roles: ["AbsenceAdministratorRole"], permissions: [] });
       cy.resizeToMobile();
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
     });
 
     it("only renders allowed groups & items", () => {
@@ -265,7 +265,7 @@ describe("Navigation Menu", () => {
     beforeEach(() => {
       cy.login({ roles: ["SubstituteAdministratorRole"], permissions: [] });
       cy.resizeToMobile();
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
     });
 
     it("only renders allowed groups & items", () => {
@@ -292,7 +292,7 @@ describe("Navigation Menu", () => {
     beforeEach(() => {
       cy.login({ roles: [], permissions: ["PersonRight"] });
       cy.resizeToMobile();
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
     });
 
     it("only renders allowed groups & items", () => {
@@ -320,7 +320,7 @@ describe("Navigation Menu", () => {
         permissions: ["RegistrationRightWeiterbildungModulanlass"],
       });
       cy.resizeToMobile();
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
     });
 
     it("only renders allowed groups & items", () => {
@@ -345,7 +345,7 @@ describe("Navigation Menu", () => {
         permissions: ["RegistrationRightWeiterbildungKurs"],
       });
       cy.resizeToMobile();
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
     });
 
     it("only renders allowed groups & items", () => {

--- a/cypress/e2e/navigationRouting.cy.ts
+++ b/cypress/e2e/navigationRouting.cy.ts
@@ -9,7 +9,7 @@ describe("Navigation & Routing", () => {
     });
 
     it("does not select any menu entry per default", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       cy.get("bkd-nav").as("desktopMenu").should("be.visible");
 
       // No group activated
@@ -60,7 +60,7 @@ describe("Navigation & Routing", () => {
     });
 
     it("selects menu entry from URL", () => {
-      cy.visit("/index.html?module=presenceControl");
+      cy.visitPortal("/index.html?module=presenceControl");
       cy.get("bkd-nav").as("desktopMenu").should("be.visible");
 
       // Activates navigation group
@@ -117,7 +117,7 @@ describe("Navigation & Routing", () => {
     });
 
     it("redirects to home for invalid item key in URL", () => {
-      cy.visit("/index.html?module=asdf");
+      cy.visitPortal("/index.html?module=asdf");
       cy.get("bkd-nav").as("desktopMenu").should("be.visible");
 
       // No group activated
@@ -174,7 +174,7 @@ describe("Navigation & Routing", () => {
     });
 
     it("applies menu entry selection to URL", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       cy.get("bkd-nav").as("desktopMenu").should("be.visible");
 
       // Group not active
@@ -242,7 +242,7 @@ describe("Navigation & Routing", () => {
     });
 
     it("visits profile (a specific sub app path of an item)", () => {
-      cy.visit(
+      cy.visitPortal(
         "index.html?locale=de-CH&module=presenceControl#/presence-control/student/5389/absences?returnparams=date%3D2023-07-03%26viewMode%3Dgrid%26lesson%3D291257",
       );
       cy.get("bkd-nav").as("desktopMenu").should("be.visible");
@@ -280,7 +280,7 @@ describe("Navigation & Routing", () => {
     });
 
     it("selects menu item from URL and expands its group", () => {
-      cy.visit("/index.html?module=presenceControl");
+      cy.visitPortal("/index.html?module=presenceControl");
       cy.get("iframe").should(
         "have.attr",
         "src",

--- a/cypress/e2e/notifications.cy.ts
+++ b/cypress/e2e/notifications.cy.ts
@@ -42,13 +42,13 @@ describe("Notifications", () => {
 
   describe("no notifications", () => {
     it("renders bell without counter", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       cy.get('[aria-label="Benachrichtigungen"]').as("toggle");
       cy.get("@toggle").get(".circle").should("be.hidden");
     });
 
     it("opens dropdown without notifications and delete button disabled", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       cy.get('[aria-label="Benachrichtigungen"]').as("toggle");
       cy.get("@toggle").click();
       cy.get("#notifications-dropdown").as("dropdown").should("exist");
@@ -68,13 +68,13 @@ describe("Notifications", () => {
     });
 
     it("renders bell with counter", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       cy.get('[aria-label="Benachrichtigungen"]').as("toggle");
       cy.get("@toggle").get(".circle").should("be.visible").contains("4");
     });
 
     it("opens dropdown showing notifications and delete button enabled", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       cy.get('[aria-label="Benachrichtigungen"]').as("toggle");
       cy.get("@toggle").click();
       cy.get("#notifications-dropdown").as("dropdown").should("exist");
@@ -97,7 +97,7 @@ describe("Notifications", () => {
     });
 
     it("deletes all notifications", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       cy.get('[aria-label="Benachrichtigungen"]').as("toggle");
       cy.get("@toggle").click();
       cy.get("#notifications-dropdown").as("dropdown").should("exist");
@@ -110,7 +110,7 @@ describe("Notifications", () => {
     });
 
     it("delete single notification", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       cy.get('[aria-label="Benachrichtigungen"]').as("toggle");
       cy.get("@toggle").click();
       cy.get("#notifications-dropdown").as("dropdown").should("exist");

--- a/cypress/e2e/serviceNavigation.cy.ts
+++ b/cypress/e2e/serviceNavigation.cy.ts
@@ -7,7 +7,7 @@ describe("Service Navigation", () => {
     });
 
     it("open/closes user settings", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       openServiceNavigation();
 
       // Close user settings menu
@@ -17,7 +17,7 @@ describe("Service Navigation", () => {
     });
 
     it("renders user settings in the service navigation", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       openServiceNavigation();
 
       cy.get("@serviceNav")
@@ -37,7 +37,7 @@ describe("Service Navigation", () => {
     // Apparently the triggering of the 'keydown' event does not work
     // when run headless
     it.skip("closes user settings on escape", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       openServiceNavigation();
 
       // Close user settings menu
@@ -47,7 +47,7 @@ describe("Service Navigation", () => {
     });
 
     it("closes user settings on select", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       openServiceNavigation();
 
       // Close user settings menu
@@ -60,7 +60,7 @@ describe("Service Navigation", () => {
     });
 
     it("closes user settings on click away", () => {
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       openServiceNavigation();
 
       // Close user settings menu
@@ -72,7 +72,7 @@ describe("Service Navigation", () => {
     it("renders language switcher in the service navigation for multilingual schools", () => {
       interceptGuiLanguagesRequest(["de-CH", "fr-CH"]);
 
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       cy.get("bkd-language-switcher")
         .find("a")
         .should((links) =>
@@ -85,7 +85,7 @@ describe("Service Navigation", () => {
     it("does not render language switcher in the service navigation for monolingual schools", () => {
       interceptGuiLanguagesRequest(["de-CH"]);
 
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       cy.get("bkd-language-switcher").should("not.exist");
     });
   });
@@ -97,7 +97,7 @@ describe("Service Navigation", () => {
 
     it("renders user settings and language switcher in the mobile navigation for multilingual schools", () => {
       interceptGuiLanguagesRequest(["de-CH", "fr-CH"]);
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       openMobileNavigation();
 
       cy.get("@serviceNav")
@@ -118,7 +118,7 @@ describe("Service Navigation", () => {
 
     it("renders user settings in the mobile navigation for monolingual schools", () => {
       interceptGuiLanguagesRequest(["de-CH"]);
-      cy.visit("/index.html");
+      cy.visitPortal("/index.html");
       openMobileNavigation();
 
       cy.get("@serviceNav")

--- a/cypress/e2e/substitutions.cy.ts
+++ b/cypress/e2e/substitutions.cy.ts
@@ -86,7 +86,7 @@ describe("Substitutions", () => {
       });
 
       it("renders inactive toggle & opens dropdown with available substitutions", () => {
-        cy.visit("/index.html");
+        cy.visitPortal("/index.html");
         cy.contains("button", "Stellvertretung ausüben").as("toggle");
 
         cy.get("@toggle").get(".icon").should("not.be.visible");
@@ -124,7 +124,7 @@ describe("Substitutions", () => {
       });
 
       it("renders active toggle & stops substitution on click", () => {
-        cy.visit("/index.html");
+        cy.visitPortal("/index.html");
         cy.contains("button", "John Lennon").as("toggle");
 
         cy.get("@toggle").get(".icon").should("not.be.visible");
@@ -150,7 +150,7 @@ describe("Substitutions", () => {
       });
 
       it("renders inactive toggle & opens dropdown with available substitutions", () => {
-        cy.visit("/index.html");
+        cy.visitPortal("/index.html");
         cy.get('[aria-label="Stellvertretung ausüben"]').as("toggle");
 
         cy.get("@toggle").get(".icon").should("be.visible");
@@ -189,7 +189,7 @@ describe("Substitutions", () => {
       });
 
       it("renders active toggle & stops substitution on click", () => {
-        cy.visit("/index.html");
+        cy.visitPortal("/index.html");
         cy.get('[aria-label="John Lennon"]').as("toggle");
 
         cy.get("@toggle").get(".icon").should("be.visible");

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -24,6 +24,18 @@ declare global {
   namespace Cypress {
     interface Chainable<Subject> {
       /**
+       * Just like `cy.visit`, but waits for the roles and permissions
+       * to be loaded.
+       */
+      visitPortal(
+        url: string,
+        options?: Partial<VisitOptions>,
+      ): Chainable<AUTWindow>;
+      visitPortal(
+        options: Partial<VisitOptions> & { url: string },
+      ): Chainable<AUTWindow>;
+
+      /**
        * Make sure the user is authenticated (i.e. add a token for
        * each scope to localStorage)
        */
@@ -50,6 +62,12 @@ declare global {
        * Expect the `aria-expanded` attribute of the current subject to have the given value.
        */
       ariaExpanded(expanded: boolean): Chainable<Subject>;
+
+      /**
+       * Like `cy.contains`, but operates within the portal iframe.
+       */
+      iframeContains(text: string): Chainable<void>;
+      iframeContains(selector: string, text: string): Chainable<void>;
     }
   }
 }

--- a/src/components/Header/MobileNav.ts
+++ b/src/components/Header/MobileNav.ts
@@ -1,7 +1,7 @@
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
-import { map } from "lit/directives/map.js";
+import { repeat } from "lit/directives/repeat.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { when } from "lit/directives/when.js";
 import { localized, msg } from "@lit/localize";
@@ -263,7 +263,11 @@ export class MobileNav extends LitElement {
           ${unsafeHTML(open ? arrowDownIcon : arrowUpIcon)}
         </button>
         <ul class="items">
-          ${map(group.items, this.renderNavItem.bind(this))}
+          ${repeat(
+            group.items,
+            (item) => item.label,
+            this.renderNavItem.bind(this),
+          )}
         </ul>
       </li>
     `;
@@ -308,12 +312,17 @@ export class MobileNav extends LitElement {
     return html`
       <nav role="navigation" aria-label=${msg("Mobile Navigation")}>
         <ul class="nav">
-          ${map(portalState.navigation, this.renderGroup.bind(this))}
+          ${repeat(
+            portalState.navigation,
+            (group) => group.label,
+            this.renderGroup.bind(this),
+          )}
         </ul>
         <div class="service-nav">
           <ul>
-            ${map(
+            ${repeat(
               userSettingsItems(portalState.locale),
+              (item) => item.key,
               this.renderSettingsItem.bind(this),
             )}
           </ul>

--- a/src/components/Header/Nav.ts
+++ b/src/components/Header/Nav.ts
@@ -1,6 +1,6 @@
 import { LitElement, css, html } from "lit";
 import { customElement } from "lit/decorators.js";
-import { map } from "lit/directives/map.js";
+import { repeat } from "lit/directives/repeat.js";
 import { localized, msg } from "@lit/localize";
 import { StateController } from "@lit-app/state";
 import { NavigationGroup } from "../../settings";
@@ -47,11 +47,14 @@ export class Nav extends LitElement {
 
   render() {
     return html`<nav role="navigation" aria-label=${msg("Hauptnavigation")}>
-      ${map(portalState.navigation, (group) =>
-        this.renderGroupToggle(
-          group,
-          group.label === portalState.navigationGroup?.label,
-        ),
+      ${repeat(
+        portalState.navigation,
+        (group) => group.label,
+        (group) =>
+          this.renderGroupToggle(
+            group,
+            group.label === portalState.navigationGroup?.label,
+          ),
       )}
     </nav>`;
   }

--- a/src/components/Header/NavGroupDropdown.ts
+++ b/src/components/Header/NavGroupDropdown.ts
@@ -1,7 +1,7 @@
 import { LitElement, css, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
-import { map } from "lit/directives/map.js";
+import { repeat } from "lit/directives/repeat.js";
 import { localized } from "@lit/localize";
 import { StateController } from "@lit-app/state";
 import { NavigationGroup, NavigationItem } from "../../settings";
@@ -125,7 +125,11 @@ export class NavGroupDropdown extends LitElement {
 
     return html`
       <ul role="menu">
-        ${map(this.group.items, this.renderItem.bind(this))}
+        ${repeat(
+          this.group.items,
+          (item) => item.key,
+          this.renderItem.bind(this),
+        )}
       </ul>
     `;
   }

--- a/src/components/Portal.ts
+++ b/src/components/Portal.ts
@@ -9,7 +9,7 @@ import { tokenState } from "../state/token-state.ts";
 import {
   activateTokenForScope,
   createOAuthClient,
-  ensureAuthenticated,
+  initAuthentication,
   logout,
 } from "../utils/auth";
 import { getInitialLocale } from "../utils/locale";
@@ -21,14 +21,11 @@ import {
   registerLightDomStyles,
   theme,
 } from "../utils/theme";
-import { initializeTokenRenewal } from "../utils/token-renewal.ts";
 
 const oAuthClient = createOAuthClient();
-initializeTokenRenewal(oAuthClient);
-
 const authReady = (async function () {
   // Start Authorization Code Flow with PKCE
-  await ensureAuthenticated(oAuthClient, getScopeFromUrl(), getInitialLocale());
+  await initAuthentication(oAuthClient, getScopeFromUrl(), getInitialLocale());
   portalState.init();
 })();
 

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const loggingEnabled = import.meta.env.DEV;
+const loggingEnabled = import.meta.env?.DEV;
 
 /**
  * Outputs the given arguments with console.log, but only in dev mode

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -11,8 +11,6 @@ const CURRENT_ACCESS_TOKEN_KEY = "CLX.LoginToken";
 const LOCALE_KEY = "uiCulture";
 const TOKEN_EXPIRE = "CLX.TokenExpire";
 
-///// localStorage /////
-
 export function getInstance(): string | null {
   return localStorage.getItem(INSTANCE_KEY);
 }
@@ -21,18 +19,25 @@ export function storeInstance(instance: string): void {
   localStorage.setItem(INSTANCE_KEY, instance);
 }
 
+export function storeLocale(locale: string) {
+  localStorage.setItem(LOCALE_KEY, locale);
+}
+
+export function getRefreshToken(scope: string): string | null {
+  return localStorage.getItem(`${REFRESH_TOKEN_KEY}_${scope}`);
+}
+
+export function storeRefreshToken(
+  scope: string,
+  refreshToken: string | null,
+): void {
+  if (refreshToken) {
+    localStorage.setItem(`${REFRESH_TOKEN_KEY}_${scope}`, refreshToken);
+  }
+}
+
 export function getAccessToken(scope: string): string | null {
   return localStorage.getItem(`${ACCESS_TOKEN_KEY}_${scope}`);
-}
-
-export function getRefreshToken(): string | null {
-  return localStorage.getItem(REFRESH_TOKEN_KEY);
-}
-
-export function storeRefreshToken(refreshToken: string | null): void {
-  if (refreshToken) {
-    localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
-  }
 }
 
 export function storeAccessToken(scope: string, accessToken: string): void {
@@ -40,11 +45,10 @@ export function storeAccessToken(scope: string, accessToken: string): void {
 }
 
 export function resetAllTokens(): void {
-  new Array(localStorage.length).fill(undefined).forEach((_, i) => {
-    const key = localStorage.key(i);
+  forEachKey(localStorage, (key) => {
     if (
       key &&
-      (key.startsWith(ACCESS_TOKEN_KEY) || key === REFRESH_TOKEN_KEY)
+      (key.startsWith(ACCESS_TOKEN_KEY) || key.startsWith(REFRESH_TOKEN_KEY))
     ) {
       localStorage.removeItem(key);
     }
@@ -52,12 +56,6 @@ export function resetAllTokens(): void {
 
   sessionStorage.removeItem(CURRENT_ACCESS_TOKEN_KEY);
 }
-
-export function storeLocale(locale: string) {
-  localStorage.setItem(LOCALE_KEY, locale);
-}
-
-///// sessionStorage /////
 
 export function getCurrentAccessToken(): string | null {
   const token = sessionStorage.getItem(CURRENT_ACCESS_TOKEN_KEY);
@@ -121,4 +119,15 @@ export function storeLoginState(
 
 export function getLoginStateRedirectUri(): string | null {
   return sessionStorage.getItem(REDIRECT_URI_KEY);
+}
+
+function forEachKey(storage: Storage, callback: (key: string) => void): void {
+  new Array(storage.length)
+    .fill(undefined)
+    .map((_, i) => storage.key(i)) // Build an array with all keys first, so when keys get deleted in the callback there is no mess with the indices
+    .forEach((key) => {
+      if (key) {
+        callback(key!);
+      }
+    });
 }

--- a/src/utils/token-renewal.ts
+++ b/src/utils/token-renewal.ts
@@ -1,8 +1,13 @@
-import { OAuth2Client } from "@badgateway/oauth2-client";
 import { tokenState } from "../state/token-state";
-import { loginUrl, redirect, refreshUrl } from "./auth";
 import { log, logLazy } from "./logging";
-import { TokenPayload, getTokenExpireIn } from "./token";
+import { getAccessToken, getRefreshToken } from "./storage";
+import {
+  TOKEN_ALMOST_EXPIRY_MS,
+  TokenPayload,
+  getTokenExpireIn,
+  getTokenPayload,
+  isTokenAlmostExpired,
+} from "./token";
 
 enum TokenType {
   Refresh = "refresh",
@@ -17,15 +22,36 @@ const expirationTimers: Record<
   access: undefined,
 };
 
-export function initializeTokenRenewal(client: OAuth2Client): void {
-  renewRefreshTokenOnExpiration(client, tokenState.refreshTokenPayload);
+/**
+ * Initialize the timers to update the current refresh and access token (has to
+ * be called only once). The timers will restart whenever a new token is set on
+ * the tokenState.
+ */
+export function initializeTokenRenewal({
+  renewRefreshToken,
+  renewAccessToken,
+}: {
+  renewRefreshToken: (scope: string, locale: string) => Promise<void>;
+  renewAccessToken: (scope: string, locale: string) => Promise<void>;
+}): void {
+  // Refresh token renewal
+  scheduleExpiration(
+    TokenType.Refresh,
+    tokenState.refreshTokenPayload,
+    renewRefreshToken,
+  );
   tokenState.onRefreshTokenUpdate((refreshToken) =>
-    renewRefreshTokenOnExpiration(client, refreshToken),
+    scheduleExpiration(TokenType.Refresh, refreshToken, renewRefreshToken),
   );
 
-  renewAccessTokenOnExpiration(client, tokenState.accessTokenPayload);
+  // Access token renewal
+  scheduleExpiration(
+    TokenType.Access,
+    tokenState.accessTokenPayload,
+    renewAccessToken,
+  );
   tokenState.onAccessTokenUpdate((accessToken) =>
-    renewAccessTokenOnExpiration(client, accessToken),
+    scheduleExpiration(TokenType.Access, accessToken, renewAccessToken),
   );
 }
 
@@ -37,63 +63,105 @@ export function clearTokenRenewalTimers(): void {
   });
 }
 
-function renewRefreshTokenOnExpiration(
-  client: OAuth2Client,
-  refreshToken: TokenPayload | null,
-): void {
-  onExpiration(TokenType.Refresh, refreshToken, () => {
-    // Get the scope of the "current" access token at the time the
-    // refresh token expires, since the user may have switched scopes
-    // in the meantime
-    const accessToken = tokenState.accessTokenPayload;
-    if (!accessToken) return;
-
-    log(`Refresh token expired, redirect to login`);
-    const { scope, locale } = accessToken;
-    redirect(loginUrl, { client, scope, locale });
-  });
-}
-
-function renewAccessTokenOnExpiration(
-  client: OAuth2Client,
-  accessToken: TokenPayload | null,
-): void {
-  onExpiration(TokenType.Access, accessToken, () => {
-    if (!accessToken) return;
-
-    const { scope, locale } = accessToken;
-    log(
-      `Access token for scope "${scope}" and locale "${locale}" expired, redirect for token fetch/refresh`,
-    );
-    redirect(refreshUrl, { client, scope, locale });
-  });
-}
-
 /**
- * Calls the given callback when the given token expires, canceling
- * ongoing timers for the given token type (if there are any).
+ * Calls the `onRenew` callback when the given token expires,
+ * canceling ongoing timers for the given token type (if there are
+ * any).
  */
-function onExpiration(
+function scheduleExpiration(
   type: TokenType,
   token: TokenPayload | null,
-  callback: () => void,
+  onRenew: (scope: string, locale: string) => Promise<void>,
 ): void {
   if (expirationTimers[type]) {
     clearTimeout(expirationTimers[type]);
   }
 
-  const expireIn = token && getTokenExpireIn(token);
-  // Don't set timer for already expired token since it will be
-  // handled by the auth.ts logic and would cause a redirection loop
-  if (expireIn && expireIn > 0) {
-    expirationTimers[type] = setTimeout(callback, expireIn);
-    logLazy(() => {
-      const { expirationTime } = token;
-      const expirationDate = new Date();
-      expirationDate.setTime(expirationTime * 1000);
-      return `Scheduled ${type} token expiration timeout in ${Math.floor(
-        expireIn / 1000 / 60,
-      )} minutes (at ${expirationDate})`;
-    });
+  if (!token) return;
+
+  // We want to schedule the timer not when the token is actually expired, but a
+  // bit before (when it will be almost expired but still valid). This is to
+  // make sure we have a valid token while we are fetching the new one, to avoid
+  // timing issues where apps would make requests with an expired token.
+  const actualExpireIn = getTokenExpireIn(token);
+  const almostExpireIn = actualExpireIn - TOKEN_ALMOST_EXPIRY_MS;
+
+  if (actualExpireIn <= 0) {
+    // Don't schedule timer for already expired token, since this can only be
+    // the case initially and is already handled by the auth.ts logic in
+    // `activateTokenForScope`).
+    return;
   }
+
+  // If we're receiving a token that is already almost expired, we want to wait
+  // until it actually expires, otherwise we'd cause a renewal loop. We even
+  // wait 1s more than the actual expiration time to make sure it is really
+  // expired and we're not receiving another token with expiration time 0 (which
+  // would result in no timer being scheduled).
+  const expireIn =
+    almostExpireIn > 0 ? almostExpireIn : Math.max(actualExpireIn + 1000, 0);
+  expirationTimers[type] = setTimeout(
+    () => tokenExpired(type, token, onRenew),
+    expireIn,
+  );
+  logLazy(() => {
+    const expirationDate = new Date();
+    expirationDate.setTime(Date.now() + expireIn);
+    return `Scheduled ${type} token expiration timeout in ${Math.round(
+      expireIn / 1000 / 60,
+    )} minutes (at ${expirationDate})`;
+  });
+}
+
+/**
+ * Calls the `onRenew` callback of only one tab (i.e. the "leader"
+ * tab), while the others will wait, to make sure we only renew a
+ * token once.
+ */
+function tokenExpired(
+  type: TokenType,
+  token: TokenPayload,
+  onRenew: (scope: string, locale: string) => Promise<void>,
+): void {
+  const { scope, locale } = token;
+  log(`Expired ${type} token for scope "${scope}" and locale "${locale}"`);
+
+  // Create a lock to make sure only the "leader" tab will actually
+  // renew the token, the others will wait and then update their
+  // tokens in `tokenState`
+  withLock(scope, async () => {
+    const actualToken =
+      type === TokenType.Access
+        ? getAccessToken(scope)
+        : getRefreshToken(scope);
+    const payload = actualToken ? getTokenPayload(actualToken) : null;
+    if (payload) {
+      if (isTokenAlmostExpired(payload)) {
+        // The tab that wins the lock first will renew the token
+        await onRenew(payload.scope, payload.locale);
+      } else {
+        // The tabs that subsequently get the lock will use the already renewed token
+        log(
+          `The ${type} token for scope "${scope}" and locale "${locale}" has already been updated by another tab`,
+        );
+        if (type === TokenType.Access) {
+          tokenState.accessToken = actualToken;
+        } else {
+          tokenState.refreshToken = actualToken;
+        }
+      }
+    }
+  });
+}
+
+/**
+ * Creates a lock per scope and makes sure only the callback of one tab at a
+ * time will be executed (leader election).
+ *
+ * See also: https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API
+ */
+function withLock(scope: string, callback: () => Promise<void>): void {
+  navigator.locks.request(`bkdTokenRenewal_${scope}`, async () => {
+    await callback();
+  });
 }

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -43,10 +43,12 @@ export function getTokenPayload(token: string): TokenPayload {
   };
 }
 
+export const TOKEN_ALMOST_EXPIRY_MS = 10 * 1000;
+
 /**
  * Returns true if the given token matches the given scope/locale & is
- * not half expired to decide wheter or not an access token can be
- * used or should be refreshed.
+ * not expired to decide whether or not an access token can be used or
+ * should be refreshed.
  */
 export function isValidToken(
   token: string | null,
@@ -59,7 +61,7 @@ export function isValidToken(
   return (
     payload.scope === scope &&
     payload.locale === locale &&
-    !isTokenHalfExpired(payload)
+    !isTokenExpired(payload)
   );
 }
 
@@ -67,18 +69,18 @@ export function isTokenExpired(token: TokenPayload | null): boolean {
   if (!token) return true;
 
   const { expirationTime } = token;
-  const now = Math.floor(Date.now() / 1000);
-  return expirationTime < now;
+  return expirationTime * 1000 < Date.now();
 }
 
-export function isTokenHalfExpired(token: TokenPayload | null): boolean {
+/**
+ * Returns false if the given token is expired or expires within the next 10
+ * seconds.
+ */
+export function isTokenAlmostExpired(token: TokenPayload | null): boolean {
   if (!token) return true;
 
-  const { issueTime, expirationTime } = token;
-  const validFor = expirationTime - issueTime;
-  const now = Math.floor(Date.now() / 1000);
-
-  return expirationTime <= now + validFor / 2;
+  const { expirationTime } = token;
+  return expirationTime * 1000 - TOKEN_ALMOST_EXPIRY_MS < Date.now();
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/typings.d.ts", "src", "public/**/*.js"]
+  "include": ["src/typings.d.ts", "src", "public/**/*.js"],
+  "exclude": ["dist", "node_modules", "public/apps"]
 }


### PR DESCRIPTION
Siehe #157

Todos:
- [x] Asynchroner `/Token` Endpunkt verwenden um abgelaufene Access Tokens zu erneuern
- [x] Neu je ein Refresh Tokens pro Scope in localStorage persistieren
- [x] Zum Login Redirecten wenn asynchrone `/Token` Erneuerung fehlschlägt (Typischerweise 40x Response, `invalid_grant`, wenn Refresh Token oder Session abgelaufen ist)
- [x] Keine Half-Expired-Überprüfung mehr → Access Token erneuern wenn ganz expired
- [x] Bei Scope Wechsel ohne gecachetes Token auf `/Login` redirecten
- [x] Bei Sprachwechsel neues Token über asynchronen `/Token` Endpunkt fetchen
- [x] Loading State wenn Token erneuert wird → ein Spinner ist IMO nicht nötig, es wird einfach die Seite nicht gerendered wie bisher
- [x] Leadership Election Mechanismus, damit nur ein Tab das Token renewed
- [x] Cypress Tests ergänzen → habe noch recht umfangreiche Tests geschrieben
- [x] Doku anpassen
- [x] auth.cy.ts failed noch im Workflow → beendet irgendwie nicht richtig, analysieren
- [x] Wenn Refresh Token abgelaufen ist (nicht 10s voher wie aktuell implementiert) soll auf Login redirected werden. Ansonsten redirected die Login Page gleich wieder zurück und es kommt zu einem Redirection Loop, da die Login-Session noch nicht abgelaufen ist.
- [x] Wird eine Stellvertretung gestartet, müssen alle Scopes die bereits aufgerufen wurden aktualisiert werden, damit die Stellvertretung in jedem Scope aktiv ist. > Lösung in #206 
- [x] Manuelles Testing mit `browserstack` Client (30 Minuten Timeout)
- [x] Squashen