### PR TITLE
Exclude /unrestricted/* from being served/cached by the service worker #190

### DIFF
--- a/doc/pwa.md
+++ b/doc/pwa.md
@@ -5,15 +5,15 @@
 The _Evento Portal_ is installable and offers a simple offline page when no internet connection is available. We use the [vite-plugin-pwa](https://github.com/vite-pwa/vite-plugin-pwa) that builds on Workbox to achieve this. The configuration is in [vite.config.ts](../vite.config.ts):
 
 - We define the Web Manifest with the appropriate colors and icons.
-- The ServiceWorker should pre-cache all necessary assets of the _Evento Portal_ to render the base layout or "shell" (`index.html`, logo, icons and JavaScript files) but not the _apps_' files in `public/apps`.
-- When building the application with `npm run build`, the ServiceWorker is generated to `dist/sw.js`, containing the file paths to pre-cache.
+- The Service Worker should pre-cache all necessary assets of the _Evento Portal_ to render the base layout or "shell" (`index.html`, logo, icons and JavaScript files) but not the _apps_' files in `public/apps`.
+- When building the application with `npm run build`, the Service Worker is generated to `dist/sw.js`, containing the file paths to pre-cache.
 
-## Testing with ServiceWorker
+## Testing with Service Worker
 
-To test the _Evento Portal_ with the ServiceWorker locally, you have to serve the app with a valid SSL certificate using the following command (with `browserstack` as `oAuthClientId` in `public/settings.js`):
+To test the _Evento Portal_ with the Service Worker locally, you have to serve the app with a valid SSL certificate using the following command (with `browserstack` as `oAuthClientId` in `public/settings.js`):
 
 ```
-npm run preview:ssl
+npm run build && npm run preview:ssl
 ```
 
 The application is served under https://bs-local.com:3000.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,13 +14,17 @@ const commonPlugins = [
       "icons/apple-touch-icon-180x180.png",
     ],
     workbox: {
-      // Exclude all files in apps directory from beeing intercepted
-      // by the service worker
-      navigateFallbackDenylist: [/^\/apps/],
+      // Exclude all files in apps/ and unrestricted/ directories from
+      // being intercepted by the service worker
+      navigateFallbackDenylist: [/^\/apps/, /^\/unrestricted/],
 
-      // Define files to be pre-cached (all except the settings files
-      // & the apps dir)
-      globIgnores: ["apps/**/*", "settings*.js"],
+      // Define files to be pre-cached with a few exceptions
+      globIgnores: [
+        "apps/**/*",
+        "settings*.js",
+        "unrestricted/**/*",
+        "assets/unrestricted-*.js",
+      ],
       globPatterns: ["**/*{js,css,html,ico,png,svg,woff}"],
     },
     manifest: {


### PR DESCRIPTION
#190

Ich konnte es lokal reproduzieren. Offenbar hatte der Service Worker das falsche index.html ausgeliefert. Habe nun `/unrestricted/index.html` vom Service Worker ausgeschlossen, damit funktioniert es bei mir. Allerdings musste ich einmal einloggen, damit der neue Service Worker installiert war...?